### PR TITLE
Minimally scope permissions in GitHub Actions workflows

### DIFF
--- a/.github/workflows/codecoverage-main.yml
+++ b/.github/workflows/codecoverage-main.yml
@@ -24,6 +24,7 @@ jobs:
     permissions:
       contents: write       # Required to check out the repo and push coverage updates to gh-pages (write implies read).
       pull-requests: write # Required for mshick/add-pr-comment to post or update sticky PR comments.
+    timeout-minutes: 60
 
     services:
       mysql:

--- a/.github/workflows/codecoverage-main.yml
+++ b/.github/workflows/codecoverage-main.yml
@@ -24,7 +24,7 @@ jobs:
     permissions:
       contents: write       # Required to check out the repo and push coverage updates to gh-pages (write implies read).
       pull-requests: write # Required for mshick/add-pr-comment to post or update sticky PR comments.
-    timeout-minutes: 60
+    timeout-minutes: 10
 
     services:
       mysql:

--- a/.github/workflows/codecoverage-main.yml
+++ b/.github/workflows/codecoverage-main.yml
@@ -13,10 +13,17 @@ on:
       - main
   workflow_dispatch:
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
 
   codecoverage:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write       # Required to check out the repo and push coverage updates to gh-pages (write implies read).
+      pull-requests: write # Required for mshick/add-pr-comment to post or update sticky PR comments.
 
     services:
       mysql:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,6 +28,7 @@ jobs:
       actions: read         # Required to restore the Composer dependency cache.
       actions: write        # Required to save the Composer dependency cache.
       pull-requests: read # Required because technote-space/get-diff-action uses the GitHub pulls API.
+    timeout-minutes: 30
     steps:
 
       - name: Checkout

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,10 +15,19 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
   cancel-in-progress: true
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   phpcs:
     name: Run PHP Code Sniffer
     runs-on: ubuntu-latest
+    permissions:
+      contents: read        # Required to clone the repo.
+      actions: read         # Required to restore the Composer dependency cache.
+      actions: write        # Required to save the Composer dependency cache.
+      pull-requests: read # Required because technote-space/get-diff-action uses the GitHub pulls API.
     steps:
 
       - name: Checkout

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,11 +24,9 @@ jobs:
     name: Run PHP Code Sniffer
     runs-on: ubuntu-latest
     permissions:
-      contents: read        # Required to clone the repo.
-      actions: read         # Required to restore the Composer dependency cache.
-      actions: write        # Required to save the Composer dependency cache.
+      contents: read
       pull-requests: read # Required because technote-space/get-diff-action uses the GitHub pulls API.
-    timeout-minutes: 30
+    timeout-minutes: 5
     steps:
 
       - name: Checkout

--- a/.github/workflows/satis-update.yml
+++ b/.github/workflows/satis-update.yml
@@ -5,10 +5,15 @@ on:
     types:
       - created
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   webhook:
     name: Send Webhook
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
 
       - name: Set Package

--- a/.github/workflows/satis-update.yml
+++ b/.github/workflows/satis-update.yml
@@ -14,6 +14,7 @@ jobs:
     name: Send Webhook
     runs-on: ubuntu-latest
     permissions: {}
+    timeout-minutes: 30
     steps:
 
       - name: Set Package

--- a/.github/workflows/satis-update.yml
+++ b/.github/workflows/satis-update.yml
@@ -14,7 +14,7 @@ jobs:
     name: Send Webhook
     runs-on: ubuntu-latest
     permissions: {}
-    timeout-minutes: 30
+    timeout-minutes: 5
     steps:
 
       - name: Set Package


### PR DESCRIPTION
This updates the GitHub Actions workflow files to:

- Grant minimally-scoped permissions to each job to adhere to the principle of least privilege
- Specify a timeout on each job to prevent runaway processes consuming too many minutes (the default is 360)

Once this PR is merged, [the Settings -> Actions -> Workflow permissions setting](https://github.com/WordPress/wordpress-playground/settings/actions) can be changed by a repo admin to "Read repository contents and packages permissions".

For more information, see [PRESS11-470](https://newfold.atlassian.net/browse/PRESS11-470).

## References

- https://docs.github.com/en/actions/reference/security/secure-use
- https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idtimeout-minutes

## Use of AI

Cursor was used with (Claude Opus 4.7 and Composer 2.0 at varying points) to analyze the repository and make the initial changes.

When this PR is marked "ready for review" it means that I have manually reviewed all permissions and timeouts that were changed and made any necessary adjustments.

As a part of the analysis, the following summary was created:

## Status

| Field | Value |
|---|---|
| Workflows scanned | 3 (`satis-update.yml`, `lint.yml`, `codecoverage-main.yml`) |
| Branch | `add/scoped-workflow-permissions` (created) |
| Permissions commit | `338d86f` |
| Timeouts commit | `b5f77e8` |


## Top-level `permissions: {}`

| Category | Entry |
|---|---|
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `satis-update.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `lint.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `codecoverage-main.yml` |


## Job-level `permissions:` additions

| Workflow file | Summary | Job | Permissions / notes |
|---|---|---|---|
| satis-update.yml | 1 job was missing a scoped `permissions:` directive | webhook | `permissions: {}` [3] |
| lint.yml | 1 job was missing a scoped `permissions:` directive | phpcs | `contents: read`, `actions: read`, `actions: write`, `pull-requests: read` [3] |
| codecoverage-main.yml | 1 job was missing a scoped `permissions:` directive | codecoverage | `contents: write`, `pull-requests: write` [3] |


## Permissions corrections (previously incorrect)

No pre-existing configured `permissions:` were identified as incorrect.

## `timeout-minutes` additions

| Workflow | Job | Minutes / action | Rationale |
|---|---|---|---|
| satis-update.yml | webhook | `30` | Webhook dispatch is quick; a modest cap prevents a stuck runner from consuming minutes indefinitely. |
| lint.yml | phpcs | `30` | PHPCS on a PHP diff set typically finishes well under this; 30 minutes is a safe upper bound for Composer plus lint. |
| codecoverage-main.yml | codecoverage | `60` | Each matrix cell runs Composer, Codeception wpunit, coverage merge, and optional gh-pages commit; 60 minutes avoids false timeouts on slower runners while still bounding runaway jobs. |


## Notes / blockers

| # | Note |
|---:|---|
| 1 | `peter-evans/repository-dispatch` is invoked with `secrets.WEBHOOK_TOKEN` only, so job `GITHUB_TOKEN` scopes were left empty for `webhook`. |
| 2 | `technote-space/get-diff-action@v6` ships a default `GITHUB_TOKEN` and uses Octokit `pulls` APIs in some code paths, so `pull-requests: read` was granted for `phpcs`. |
| 3 | `contents: write` on `codecoverage` follows GitHub’s model (sufficient for checkout and for `git-auto-commit-action` pushing to `gh-pages`). Forked PRs may still hit GitHub limits for PR comments or pushes; that behavior is unchanged from before this audit. |


